### PR TITLE
72 set no to be default locale

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -23,13 +23,7 @@ export default function LocaleLayout({
 	const messages = useMessages();
 	const cookieStore = cookies();
 	const savedMode = cookieStore.get("themeMode");
-	const prefersDarkMode =
-		typeof window !== "undefined" &&
-		window.matchMedia &&
-		window.matchMedia("(prefers-color-scheme: dark)").matches;
-	const savedTheme =
-		(savedMode?.value as PaletteMode) ??
-		(prefersDarkMode ? "dark" : "light");
+	const savedTheme = (savedMode?.value ?? "dark") as PaletteMode;
 	return (
 		<html lang={locale}>
 			<NextIntlClientProvider locale={locale} messages={messages}>

--- a/contexts/ThemeModeProvider.tsx
+++ b/contexts/ThemeModeProvider.tsx
@@ -28,9 +28,7 @@ const ThemeModeProvider: React.FC<ThemeModeProviderProps> = ({
 	const colorMode = useMemo(
 		() => ({
 			toggleColorMode: () => {
-				setMode((prevMode) =>
-					prevMode === "light" ? "dark" : "light"
-				);
+				setMode((prevMode) => (prevMode === "dark" ? "light" : "dark"));
 			},
 			mode,
 		}),

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,6 +3,8 @@ import createMiddleware from "next-intl/middleware";
 export default createMiddleware({
 	locales: ["no", "en"],
 
+	// If Accept-Language header in HTTP request is anything
+	// other than "no", this is automatically ignored.
 	defaultLocale: "no",
 });
 


### PR DESCRIPTION
- Dark mode is now default theme
- "no" is now default locale
  - Does not work if the Accept Language header in the HTTP request is set. (Which it often is)